### PR TITLE
fix(sensitive):private_key_pem

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,7 @@ output "public_key_openssh" {
 
 output "private_key_pem" {
   value = tls_private_key.generated.private_key_pem
+  sensitive = true
 }
 
 output "public_key_filepath" {


### PR DESCRIPTION
https://github.com/mitchellh/terraform-aws-dynamic-keys/issues/6
https://github.com/jina-ai/terraform-jina-jinad-aws/issues/4

---

BTW, plz make sure  if `public_key_filepath` need to add a attribute that `sensitive = true` for `terraform v0.15.0`